### PR TITLE
Fix security repo

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,8 +33,7 @@
   template:
     src: sources.list.j2
     dest: "{{ apt_sources_file }}"
-  when: (apt_sources_file is defined) and
-        (apt_sources_file != "")
+  when: (apt_sources_file is defined) and apt_sources_file
   become: yes
   register: create_sources_list
   tags: ["apt-sources"]
@@ -43,7 +42,7 @@
   apt:
     update_cache: yes
   become: yes
-  when: ((add_apt_keys.changed is defined and add_apt_keys.changed == True)) or
+  when: ((add_apt_keys.changed is defined and add_apt_keys.changed)) or
         (create_sources_list.changed) or
-        (apt_sources_always_update_cache|bool == True)
+        (apt_sources_always_update_cache|bool)
   tags: ["apt-sources","skip_ansible_lint"]

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -12,7 +12,7 @@ apt_sources_repos:
 - "{{ ansible_distribution_release }}-security"
 
 apt_sources_security_url: "http://security.ubuntu.com/ubuntu/"
-apt_sources_security_repo: "{{ ansible_distribution_release }}-updates"
+apt_sources_security_repo: "{{ ansible_distribution_release }}-security"
 
 # This is what http://mirrors.ubuntu.com/mirrors.txt suggests as
 # the most generic URL. Consider overriding it with a country-specific


### PR DESCRIPTION
Security repo should be {{ ansible_distribution_release }}-security, not {{ ansible_distribution_release }}-updates. At least, this is the case in Ubuntu bionic